### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -6,7 +6,6 @@ on:
       - created
 
 permissions:
-  contents: read
   contents: write
 
 jobs:

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -6,6 +6,7 @@ on:
       - created
 
 permissions:
+  contents: read
   contents: write
 
 jobs:

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -5,6 +5,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: write
+
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/benja2998/multitoolplusplus/security/code-scanning/2](https://github.com/benja2998/multitoolplusplus/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimum permissions required for the workflow to function correctly. Based on the workflow's actions:
- `contents: read` is needed to access repository contents.
- `contents: write` is required for uploading release assets and updating the release body.

The `permissions` block will be added at the root level, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
