### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue-closer.yml
+++ b/.github/workflows/issue-closer.yml
@@ -1,5 +1,8 @@
 name: Close Non-compliant issues
 
+permissions:
+  issues: write
+
 on:
   issues:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/benja2998/multitoolplusplus/security/code-scanning/1](https://github.com/benja2998/multitoolplusplus/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the required permissions. Since the workflow only needs to close issues and add comments, the `issues: write` permission is sufficient. This change ensures that the workflow has the minimum necessary permissions and avoids granting unnecessary access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
