### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '*/3 * * * *'  # Runs every 3 minutes
 
+permissions:
+  contents: write
+
 jobs:
   update-copyright-year:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/benja2998/multitoolplusplus/security/code-scanning/3](https://github.com/benja2998/multitoolplusplus/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow involves reading and writing to the repository's contents (e.g., modifying and committing changes to `README.md`), we should explicitly grant `contents: write` permission. This ensures that the workflow has only the necessary permissions to perform its tasks and no more.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. This will ensure that the `GITHUB_TOKEN` is limited to the required permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
