### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,5 +1,8 @@
 name: Coverage Reporting to Coveralls
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/benja2998/multitoolplusplus/security/code-scanning/4](https://github.com/benja2998/multitoolplusplus/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily needs to read repository contents (`contents: read`) and use the `GITHUB_TOKEN` to upload coverage data to Coveralls. No write permissions are required.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
